### PR TITLE
Update README.md

### DIFF
--- a/1. Server-Side Scenarios/msal-client-credential-secret-high-availability/README.md
+++ b/1. Server-Side Scenarios/msal-client-credential-secret-high-availability/README.md
@@ -14,6 +14,7 @@ products:
   - azure-active-directory
   - ms-graph
 description: "This sample demonstrates how run a daemon console app, with an in-memory token cache with size eviction, to get an access token for many tenants to call Microsoft Graph using MSAL4J."
+urlFragment: ms-identity-java-server-side-scenario-msal-client-cred-secret-high-availability 
 ---
 
 # MSAL Java sample demonstrating how a daemon console application can call Microsoft Graph using its own identity


### PR DESCRIPTION
The URL fragment is constructed from the H1 if a metadata value is not supplied. There are a number of samples with the same H1 value. I would not recommend this practice.

This change: adds a URL fragment to fix metadata failure 