### PR TITLE
Update AuthFilter.java to support x-forwarded-proto header

### DIFF
--- a/1-server-side/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthFilter.java
+++ b/1-server-side/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthFilter.java
@@ -38,9 +38,9 @@ public class AuthFilter implements Filter {
             HttpServletResponse httpResponse = (HttpServletResponse) response;
             try {
                 String currentUri = httpRequest.getRequestURL().toString();
-                String realProto=httpRequest.getHeader("x-forwarded-proto");
-                if(realProto!=null)
-                    currentUri=currentUri.replaceFirst("http", realProto);
+                String realProto = httpRequest.getHeader("x-forwarded-proto");
+                if (realProto!=null)
+                    currentUri = currentUri.replaceFirst("http", realProto);
                 String path = httpRequest.getServletPath();
                 String queryStr = httpRequest.getQueryString();
                 String fullUrl = currentUri + (queryStr != null ? "?" + queryStr : "");

--- a/1-server-side/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthFilter.java
+++ b/1-server-side/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthFilter.java
@@ -39,7 +39,7 @@ public class AuthFilter implements Filter {
             try {
                 String currentUri = httpRequest.getRequestURL().toString();
                 String realProto = httpRequest.getHeader("x-forwarded-proto");
-                if (realProto!=null)
+                if (realProto != null)
                     currentUri = currentUri.replaceFirst("http", realProto);
                 String path = httpRequest.getServletPath();
                 String queryStr = httpRequest.getQueryString();

--- a/1-server-side/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthFilter.java
+++ b/1-server-side/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthFilter.java
@@ -38,6 +38,9 @@ public class AuthFilter implements Filter {
             HttpServletResponse httpResponse = (HttpServletResponse) response;
             try {
                 String currentUri = httpRequest.getRequestURL().toString();
+                String realProto=httpRequest.getHeader("x-forwarded-proto");
+                if(realProto!=null)
+                    currentUri=currentUri.replaceFirst("http", realProto);
                 String path = httpRequest.getServletPath();
                 String queryStr = httpRequest.getQueryString();
                 String fullUrl = currentUri + (queryStr != null ? "?" + queryStr : "");


### PR DESCRIPTION
Proposed fix aims to avoid the error message below when trying to deploy the service in a host behind a Load Balancer or Proxy, such as Azure App Service:

> 2024-05-22 16:27:42.895  WARN 93 --- [Thread-4] c.m.a.m.ConfidentialClientApplication    : [Correlation ID: 7cad2271-da47-4ec3-9c50-c2f548baa885] Execution of class com.microsoft.aad.msal4j.AcquireTokenByAuthorizationGrantSupplier failed: AADSTS500112: The reply address 'http://xxx.azurewebsites.net/msal4jsample/secure/aad' does not match the reply address 'https://xxx.azurewebsites.net/msal4jsample/secure/aad' provided when requesting Authorization code. Trace ID: 226282d8-4ef7-4094-b3ad-c5563b121b00 Correlation ID: 7cad2271-da47-4ec3-9c50-c2f548baa885 Timestamp: 2024-05-22 16:27:42Z

The proposed code change now retrieves the original protocol used by the client from the `x-forwarded-proto` header and replaces the scheme in the current URL with this original protocol. This ensures that the redirect URI used by the application matches the original URL as seen by the client, even when the application is behind a reverse proxy or load balancer.