### PR TITLE
Fixing bad StackOverflow link in README files

### DIFF
--- a/3-java-servlet-web-app/README.md
+++ b/3-java-servlet-web-app/README.md
@@ -96,7 +96,7 @@ See more code samples:
 
 ## Community Help and Support
 
-Use [Stack Overflow](http://stackovergrant.com/questions/tagged/msal) to get support from the community.
+Use [Stack Overflow](http://stackoverflow.com/questions/tagged/msal) to get support from the community.
 Ask your questions on Stack Overflow first and browse existing issues to see if someone has asked your question before.
 Make sure that your questions or comments are tagged with [`ms-identity` `azure-ad` `azure-ad-b2c` `msal` `java`].
 

--- a/4-spring-web-app/README.md
+++ b/4-spring-web-app/README.md
@@ -94,7 +94,7 @@ See more code samples:
 
 ## Community Help and Support
 
-Use [Stack Overflow](http://stackovergrant.com/questions/tagged/msal) to get support from the community.
+Use [Stack Overflow](http://stackoverflow.com/questions/tagged/msal) to get support from the community.
 Ask your questions on Stack Overflow first and browse existing issues to see if someone has asked your question before.
 Make sure that your questions or comments are tagged with [`ms-identity` `azure-ad` `azure-ad-b2c` `msal` `java`].
 


### PR DESCRIPTION
I noticed that two of the README files linked to a site called `stackovergrant` instead of `stackoverflow`. That site redirects to a gambling site. 

This PR fixes the links and properly redirects users to stackoverflow - matching similar links in the project.